### PR TITLE
Adding script for dynamic cross dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ client/server
 .vscode-test
 *.vsix
 .history
+.yalc
+yalc.lock

--- a/linkWollokTs.sh
+++ b/linkWollokTs.sh
@@ -1,0 +1,57 @@
+#
+# Links Wollok TS project into this one, using yalc. Anytime you need to update the dependency project,
+# simply execute
+#
+# $ yalc push
+#
+# on wollok-ts directory.
+#
+# Usage:
+# linkWollokTs.sh folder 
+# linkWollokTs.sh        # default, uses ../wollok-ts as Wollok TS folder
+# linkWollokTs.sh help   # for details
+#
+# Once you're set, you should replace the dependency in current package.json
+
+ERROR_COLOR='\033[1;31m'
+NO_COLOR='\033[0m'
+
+if [ $1 == "help" ];
+then
+  COMMAND_COLOR='\033[0;34m'
+  ARG_COLOR='\033[0;33m'
+
+  echo -e "${COMMAND_COLOR}linkWollokTs:${NO_COLOR} links a local Wollok TS environment into this project."
+  echo -e "  ${ARG_COLOR}Optional single argument${NO_COLOR}: the folder where Wollok TS is located."
+  echo "  Assuming ../wollok-ts if not present."
+  exit 0
+fi
+
+if [ -z "$1" ];
+then
+  WOLLOK_TS_DIR=../wollok-ts
+else
+  WOLLOK_TS_DIR=$1
+fi
+
+if [ ! -f "$WOLLOK_TS_DIR/package.json" ];
+then
+  echo -e "${ERROR_COLOR}No package.json found in $WOLLOK_TS_DIR folder.${NO_COLOR}"
+  exit 1
+fi
+
+CURRENT_DIR=$PWD
+
+# Install yalc cross dependency management
+npm install -g yalc
+
+# Publish wollok-ts dependency
+cd $WOLLOK_TS_DIR
+echo "Moving to $(pwd)"
+yalc publish
+
+# Go back to our project
+cd $CURRENT_DIR
+echo "Moving to $(pwd)"
+yalc add wollok-ts
+npm i

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
     "lint": "cd client && eslint . --ignore-path ../.eslintignore && cd ../server && eslint . --ignore-path ../.eslintignore && cd ..",
     "lint:fix": "cd client && eslint . --fix && cd ../server && eslint . --fix && cd ..",
-    "test": "npm run lint && sh ./scripts/e2e.sh",
+    "test": "npm run lint && sh ./scripts/e2e.sh"
   },
   "dependencies": {
     "wollok-ts": "3.0.6"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "lint": "cd client && eslint . --ignore-path ../.eslintignore && cd ../server && eslint . --ignore-path ../.eslintignore && cd ..",
     "lint:fix": "cd client && eslint . --fix && cd ../server && eslint . --fix && cd ..",
     "test": "npm run lint && sh ./scripts/e2e.sh",
-    "upgrade-wollok-ts": "npm uninstall wollok-ts && npm i file://~/workspace/wollok-dev/wollok-ts/wollok-ts-3.0.6.tgz"
   },
   "dependencies": {
     "wollok-ts": "3.0.6"


### PR DESCRIPTION
La idea es poder tener en dos proyectos

- wollok-ts
- wollok-linter

y que cuando hagas un cambio en TS rápidamente lo puedas probar en el linter. La solución que probé y me anduvo fue [ésta](https://www.viget.com/articles/how-to-use-local-unpublished-node-packages-as-project-dependencies/). Después voy a agregar una página en la wiki para mostrar cómo se hace, con gifs, pero por lo pronto me armé un script que automatiza la relación entre ambos proyectos la primera vez. Después solo tenés que hacer

```bash
yalc push
```

cada vez que metés un cambio en wollok-ts, y lo ves automágicamente en el linter. De hecho me di cuenta de que no compilaba porque hay un cambio en el branch donde estoy parado en wollok-ts, y eso ya me pareció cool.
